### PR TITLE
Add .gitattributes to override *.inc files being Pawn instead of SourcePawn

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.inc text diff=pawn

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
+# Set default behavior for line endings
+* text=auto
+
 *.inc text diff=pawn


### PR DESCRIPTION
No functional changes here, just git and github specifics.